### PR TITLE
Don't override global moretrees

### DIFF
--- a/override.lua
+++ b/override.lua
@@ -1,6 +1,7 @@
 -- hardtrees/override.lua
 hardtrees.override = {} -- override global variable
 
+local moretrees = false
 -- if moretrees, then moretrees true
 if minetest.get_modpath("moretrees") then moretrees = true end
 


### PR DESCRIPTION
This mod is currently overriding the global `moretrees` supplied by the respective mod.
This global is a necessary interface for other mods using moretrees. For example, installing hardtrees together with moretrees and plantlife will cause a crash because plantlife cannot access that interface anymore.
By simply making this variable local, this compatability issue is fixed.