### PR TITLE
Fix settings, add settings, dig through dirt to get rocks

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,35 +1,34 @@
 -- hardtrees/init.lua
-hardtrees = {} -- global variables
+
+hardtrees = { -- global variables
+	require_tools = minetest.settings:get_bool("hardtrees_require_tools", true),
+	rock_tools = minetest.settings:get_bool("hardtrees_rock_tools", true),
+	add_rocks = minetest.settings:get_bool("hardtrees_add_rocks", true),
+	gen_rocks = minetest.settings:get_bool("hardtrees_gen_rocks", true),
+	rock_distance = tonumber(minetest.settings:get("hardtrees_rock_distance")) or 5,
+	rock_interval = tonumber(minetest.settings:get("hardtrees_rock_interval")) or 60,
+	rock_gen_chance = tonumber(minetest.settings:get("hardtrees_rock_gen_chance")) or 13,
+	rock_dig_chance = tonumber(minetest.settings:get("hardtrees_rock_dig_chance")) or 10,
+	gen_sticks = minetest.settings:get_bool("hardtrees_gen_sticks", true),
+	stick_distance = tonumber(minetest.settings:get("hardtrees_stick_distance")) or 3,
+	stick_interval = tonumber(minetest.settings:get("hardtrees_stick_interval")) or 1440,
+	stick_gen_chance = tonumber(minetest.settings:get("hardtrees_stick_gen_chance")) or 50,
+	stick_dig_chance = tonumber(minetest.settings:get("hardtrees_stick_dig_chance")) or 5,
+}
+
 hardtrees.modpath = minetest.get_modpath("hardtrees") -- modpath
 hardtrees.worldpath = minetest.get_worldpath() -- worldpath
-modpath = hardtrees.modpath -- modpath
+local modpath = hardtrees.modpath -- modpath shortcut
 
--- [function] read config
-function hardtrees.conf()
-  local f = io.open(hardtrees.worldpath.."/hardtrees_conf.txt", "r") -- open file
-  if f == nil then dofile(hardtrees.modpath.."/conf.txt") end -- read config
-  -- check for nil or unset values
-  if not require_tools then local require_tools = true end -- require tools
-  if not rock_tools then local rock_tools = true end -- rock tools
-  if not gen_rocks then local gen_rocks = true end -- generate rocks
-  if not rock_distance then local rock_distance = 5 end -- rock generation distance
-  if not rock_interval then local rock_interval = 60 end -- rock generation interval
-  if not rock_chance then local rock_chane = 13 end -- rock generation chance
-  if not gen_sticks then local gen_sticks = true end -- generate sticks
-  if not stick_distance then local stick_distance = 3 end -- stick generation distance
-  if not stick_interval then local stick_interval = 1440 end -- stick generation interval
-  if not stick_chance then local stick_chance = 50 end -- stick generation chance
-end
 
-hardtrees.conf()
 
 -- load generation lua
-if gen_rocks == true then dofile(modpath.."/rocks.lua") end -- rocks
-if gen_sticks == true then dofile(modpath.."/sticks.lua") end -- sticks
+if hardtrees.add_rocks then dofile(modpath.."/rocks.lua") end -- rocks
+if hardtrees.gen_sticks then dofile(modpath.."/sticks.lua") end -- sticks
 
 -- load optional lua
-if require_tools == true then dofile(modpath.."/override.lua") end -- tree & leave overrides
-if rock_tools == true then
+if hardtrees.require_tools then dofile(modpath.."/override.lua") end -- tree & leave overrides
+if hardtrees.rock_tools then
   dofile(modpath.."/tools.lua") -- tools
   dofile(modpath.."/recipes.lua") -- recipes
 end

--- a/override.lua
+++ b/override.lua
@@ -137,6 +137,11 @@ if minetest.get_modpath("moretrees") then
   hardtrees.override.leaf("moretrees:fir_leaves", "moretrees:fir_sapling")
   hardtrees.override.leaf("moretrees:fir_leaves_bright", "moretrees:fir_sapling")
 
+  -- moretrees:jungletree
+  hardtrees.override.tree("moretrees:jungletree_trunk")
+  hardtrees.override.leaf("moretrees:jungletree_leaves_red", "default:junglesapling")
+  hardtrees.override.leaf("moretrees:jungletree_leaves_yellow", "default:junglesapling")
+
   -- moretrees:palm
   hardtrees.override.moretrees("palm")
 

--- a/override.lua
+++ b/override.lua
@@ -19,6 +19,10 @@ end
 
 -- [function] override leaf nodes
 function hardtrees.override.leaf(name, sapling)
+  if hardtrees.stick_dig_chance <= 0 then
+    return
+  end
+
   -- if leaf and sapling register, override
   if minetest.registered_nodes[name] and minetest.registered_nodes[sapling] then
     minetest.override_item(name, {
@@ -28,9 +32,9 @@ function hardtrees.override.leaf(name, sapling)
   		max_items = 2,
   		items = {
         {
-  				-- player will get sticks with 1/7 chance
+  				-- player will get sticks with 1/5 chance by default
   				items = {"default:stick"},
-  				rarity = 5,
+  				rarity = hardtrees.stick_dig_chance,
   			},
   			{
   				-- player will get sapling with 1/20 chance
@@ -48,6 +52,37 @@ function hardtrees.override.leaf(name, sapling)
     minetest.log("action", "WARNING: [hardtrees] "..name.." and "..sapling.." not registered, could not override.")
   end
 end
+
+-- [function] override dirt nodes to drop rocks
+function hardtrees.override.dirt(name)
+  if hardtrees.rock_dig_chance <= 0 then
+    return
+  end
+
+  -- if dirt is registered, override
+  if minetest.registered_nodes[name] then
+    minetest.override_item(name, {
+      drop = {
+  		max_items = 1,
+  		items = {
+        {
+  				-- player will get a rock with 1/10 chance by default
+  				items = {"hardtrees:rock"},
+  				rarity = hardtrees.rock_dig_chance,
+  			},
+  			{
+  				-- player will get leaves
+  				items = {name},
+  			}
+  		}
+  	},
+    })
+  else
+    minetest.log("action", "WARNING: [hardtrees] "..name.." not registered, could not override.")
+  end
+end
+
+
 
 -- [function] override moretrees
 function hardtrees.override.moretrees(name)
@@ -76,6 +111,16 @@ hardtrees.override.leaf("default:acacia_leaves", "default:acacia_sapling")
 hardtrees.override.tree("default:aspen_tree")
 hardtrees.override.leaf("default:aspen_leaves", "default:aspen_sapling")
 
+hardtrees.override.dirt("default:dirt")
+hardtrees.override.dirt("default:dirt_with_grass")
+hardtrees.override.dirt("default:dirt_with_grass_footsteps")
+hardtrees.override.dirt("default:dirt_with_dry_grass")
+hardtrees.override.dirt("default:dirt_with_snow")
+hardtrees.override.dirt("default:dirt_with_rainforest_litter")
+hardtrees.override.dirt("default:dirt_with_coniferous_litter")
+hardtrees.override.dirt("default:dry_dirt")
+hardtrees.override.dirt("default:dry_dirt_with_dry_grass")
+
 -- [MORETREES OVERRIDES]
 if minetest.get_modpath("moretrees") then
   -- moretrees:apple_tree
@@ -91,11 +136,6 @@ if minetest.get_modpath("moretrees") then
   hardtrees.override.tree("moretrees:fir_trunk")
   hardtrees.override.leaf("moretrees:fir_leaves", "moretrees:fir_sapling")
   hardtrees.override.leaf("moretrees:fir_leaves_bright", "moretrees:fir_sapling")
-
-  -- moretrees:jungletree
-  hardtrees.override.tree("moretrees:jungletree_trunk")
-  hardtrees.override.leaf("moretrees:jungletree_leaves_red", "default:junglesapling")
-  hardtrees.override.leaf("moretrees:jungletree_leaves_yellow", "default:junglesapling")
 
   -- moretrees:palm
   hardtrees.override.moretrees("palm")

--- a/rocks.lua
+++ b/rocks.lua
@@ -1,5 +1,3 @@
--- hardtrees/rocks.lua
-hardtrees.conf() -- read conf
 --[[ ROCK
 hardtrees:rock
 
@@ -38,17 +36,19 @@ minetest.register_node("hardtrees:rock", {
 	}
 })
 
--- [abm] rock placment
-minetest.register_abm({
-  nodenames = { "default:cobble", "default:stone", "default:mossycobble", "default:clay", "default:sandstone" },
-  neighbors = { "air" },
-  interval = rock_interval,
-  chance = rock_chance,
-  action = function(pos, node)
-    if minetest.get_node({ x = pos.x, y = pos.y + 1, z = pos.z}).name == "air" then -- if node is air, place
-      if not minetest.find_node_near({x = pos.x, y = pos.y +1, z = pos.z}, rock_distance, "hardtrees:rock") then
-        minetest.set_node({x = pos.x, y = pos.y + 1, z = pos.z}, {name = "hardtrees:rock"})
-      end
-    end
-  end,
-})
+if hardtrees.gen_rocks then
+	-- [abm] rock placment
+	minetest.register_abm({
+	  nodenames = { "default:cobble", "default:stone", "default:mossycobble", "default:clay", "default:sandstone" },
+	  neighbors = { "air" },
+	  interval = hardtrees.rock_interval,
+	  chance = hardtrees.rock_gen_chance,
+	  action = function(pos, node)
+	    if minetest.get_node({ x = pos.x, y = pos.y + 1, z = pos.z}).name == "air" then -- if node is air, place
+	      if not minetest.find_node_near({x = pos.x, y = pos.y +1, z = pos.z}, hardtrees.rock_distance, "group:rock") then
+		minetest.set_node({x = pos.x, y = pos.y + 1, z = pos.z}, {name = "hardtrees:rock"})
+	      end
+	    end
+	  end,
+	})
+end

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,0 +1,13 @@
+hardtrees_require_tools (Require tools to cut down trees) bool true
+hardtrees_rock_tools (Add rock tools that can be crafted without cutting down trees) bool true
+hardtrees_add_rocks (Add rocks that can be used to make rock tools) bool true
+hardtrees_gen_rocks (Generate rocks on top of stone over time with an ABM) bool true
+hardtrees_rock_distance (Minimum allowable distance between generated rocks) int 5
+hardtrees_rock_interval (Amount of time, in seconds, it takes between rock generations) int 60
+hardtrees_rock_gen_chance (The chance that any stone node will have a rock placed on top of it, equal to 1/chance) int 13
+hardtrees_rock_dig_chance (The chance that any dirt node will drop a rock upon being dug, equal to 1/chance, or use 0 to disable) int 10
+hardtrees_gen_sticks (Allow leaf nodes to randomly drop sticks onto the ground) bool true
+hardtrees_stick_distance (Maximum distance between leaves and tree nodes to allow sticks to generate) int 3
+hardtrees_stick_interval (Amount of time, in seconds, it takes between stick generations) int 1440
+hardtrees_stick_gen_chance (The chance that any leaf node will randomly drop a stick as a result of the generation ABM, equal to 1/chance) int 50
+hardtrees_stick_dig_chance (The chance that any leaf node will drop a stick upon being dug, equal to 1/chance, or use 0 to disable) int 5

--- a/sticks.lua
+++ b/sticks.lua
@@ -1,5 +1,3 @@
--- hardtrees/sticks.lua
-hardtrees.conf() -- read conf
 --[[ STICKS
 Sticks are generated vai ABM every 14440 seconds if the chunk is active. They
 are found on nodes within the group crumbly. This includes, dirt sand, and
@@ -25,11 +23,11 @@ end
 minetest.register_abm({
   nodenames = { "group:crumbly" },
   neighbors = { "group:tree", "group:leaves", "air" },
-  interval = stick_interval,
-  chance = stick_chance,
+  interval = hardtrees.stick_interval,
+  chance = hardtrees.stick_gen_chance,
   action = function(pos, node)
     if minetest.get_node({ x = pos.x, y = pos.y + 1, z = pos.z}).name == "air" then -- if node is air, place
-      if minetest.find_node_near({x = pos.x, y = pos.y + 1, z = pos.z}, stick_distance, "group:tree") then
+      if minetest.find_node_near({x = pos.x, y = pos.y + 1, z = pos.z}, hardtrees.stick_distance, "group:tree") then
       	if math.random(1,3) < 3 then -- math random to make more rare
           local number = math.random(1,2) -- place 1 or 2
           hardtrees.drop_item({x = pos.x, y = pos.y + 1, z = pos.z}, {name = "default:stick"}, number) -- drop stick


### PR DESCRIPTION
The old settings system used for this is awfully broken. The defaults don't work at all; they're all sent to variables local to only the functions that check if each exist. Even if they weren't, the various boolean settings would never be false, because `not false` equals `true` in an if statement. As the cherry on top, one of the locals was misspelled "rock_chane". This pull request instead uses the minetest.settings object and settingtypes.txt, which, aside from working in general, also enables configuration from the main menu, if you look in "all settings" > "mods" > "hardtrees". Lastly, these settings are now all contained within the `hardtrees` global table. This removes the risk of incompatability through accidentally overwriting some other mod's global table that happened to have the same name as one of these settings.

Additionally, some new settings are used. `gen_rocks` now only pertains to the rock generation ABM, while `add_rocks` is used only to determine if rocks are added as items or not. There are also settings to change the chance of obtaining sticks by digging leaves, and a new chance to obtain rocks by digging dirt.

There are some other miscellaneous changes as well. Using 0 for stick or rock dig chances will disable the chance to dig up those items. The chance to get sticks was commented as 1/7, when it was actually 1/5. Lastly, the rock generation ABM now looks for nearby "group:rock" rather than "hardtrees:rock", which gives the rock group an actual purpose, as mods that override many nodes may incidentally add other versions of rocks that would suddenly not count towards the ABM otherwise.